### PR TITLE
Feature/api error handling

### DIFF
--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -10,7 +10,8 @@ type State = {
   list: {
     displayName: string,
     queryName: string
-  }[] | [] 
+  }[] | [],
+  error: string
 }
 
 class App extends React.Component<Props, State> {
@@ -18,28 +19,31 @@ class App extends React.Component<Props, State> {
     super(props)
     this.state = {
       list: [],
+      error: ''
     }
   }
 
   componentDidMount() {
     getLists()
-    .then(data => {
-      this.setState({ list: data }, () => console.log(data))
-    })
+      .then(data => {
+        this.setState({ list: data })
+      })
+      .catch(error => this.setState({ error }, () => console.log(this.state)))
+  }
     
-
 // This is only here as a test
 //     getTypeOf( "hardcover-fiction" )
 //     .then(data => console.log(data))
-  }
 
   render() {
     return (
       <main className="App">
         <Navbar />
-        {!this.state.list.length 
-          ? <h2>Loading...</h2>
-          : <List list={this.state.list} />}
+        {this.state.error && <h2>{this.state.error}</h2>}
+        {!this.state.list.length
+          ? !this.state.error && <h2>Loading...</h2>
+          : <List list={this.state.list} />
+        }
       </main>
     )
   }

--- a/src/Components/App/App.tsx
+++ b/src/Components/App/App.tsx
@@ -28,7 +28,7 @@ class App extends React.Component<Props, State> {
       .then(data => {
         this.setState({ list: data })
       })
-      .catch(error => this.setState({ error }, () => console.log(this.state)))
+      .catch(error => this.setState({ error }))
   }
     
 // This is only here as a test

--- a/src/util/api-calls.ts
+++ b/src/util/api-calls.ts
@@ -3,7 +3,7 @@ import {cleanListData} from './utilities'
 // ***** ----- Fetching ----- ***** //
 
 export const getLists = () => {
-  return fetch('https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b')
+  return fetch('http://httpstat.us/416')
     .then(response => {
       if (response.ok) {
         return response.json()
@@ -25,11 +25,11 @@ export const getTypeOf = ( typeOf: string ) => {
 
 function handleError(status: number) {
   if (status === 404) {
-    throw ('Sorry, page not found.')
+    throw ('404 | Sorry, page not found.')
   }
 
   if (status === 500) {
-    throw ('Sorry, this page isn\'t working.')
+    throw ('500 | Sorry, this page isn\'t working.')
   }
 
   throw ('Sorry, something went wrong.')

--- a/src/util/api-calls.ts
+++ b/src/util/api-calls.ts
@@ -3,7 +3,7 @@ import {cleanListData} from './utilities'
 // ***** ----- Fetching ----- ***** //
 
 export const getLists = () => {
-  return fetch('http://httpstat.us/416')
+  return fetch('https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b')
     .then(response => {
       if (response.ok) {
         return response.json()

--- a/src/util/api-calls.ts
+++ b/src/util/api-calls.ts
@@ -1,14 +1,9 @@
 import {cleanListData} from './utilities'
 
-// Maybe getCategoryOf and error handling?
-
-const listEndpoint = 'https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b'
-const errorEndpoint = 'https://httpstat.us/500'
-
 // ***** ----- Fetching ----- ***** //
 
 export const getLists = () => {
-  return fetch(errorEndpoint)
+  return fetch('https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b')
     .then(response => {
       if (response.ok) {
         return response.json()
@@ -19,6 +14,8 @@ export const getLists = () => {
     .then(data => cleanListData(data.results))
 }
 
+// Maybe getCategoryOf?
+
 export const getTypeOf = ( typeOf: string ) => {
   return fetch(`https://api.nytimes.com/svc/books/v3/lists/current/${typeOf}.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b`)
     .then(response => response.json())
@@ -28,12 +25,12 @@ export const getTypeOf = ( typeOf: string ) => {
 
 function handleError(status: number) {
   if (status === 404) {
-    throw Error('404')
+    throw ('Sorry, page not found.')
   }
 
   if (status === 500) {
-    throw Error('500')
+    throw ('Sorry, this page isn\'t working.')
   }
 
-  throw Error('Sorry, something went wrong.')
+  throw ('Sorry, something went wrong.')
 }

--- a/src/util/api-calls.ts
+++ b/src/util/api-calls.ts
@@ -3,7 +3,9 @@ import {cleanListData} from './utilities'
 // Maybe getCategoryOf and error handling?
 
 const listEndpoint = 'https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b'
-const errorEndpoint = 'https://httpstat.us/404'
+const errorEndpoint = 'https://httpstat.us/500'
+
+// ***** ----- Fetching ----- ***** //
 
 export const getLists = () => {
   return fetch(errorEndpoint)
@@ -12,13 +14,26 @@ export const getLists = () => {
         return response.json()
       }
 
-      console.log(response)
+      handleError(response.status)
     })
     .then(data => cleanListData(data.results))
-    .catch(error => console.log(error))
 }
 
 export const getTypeOf = ( typeOf: string ) => {
   return fetch(`https://api.nytimes.com/svc/books/v3/lists/current/${typeOf}.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b`)
     .then(response => response.json())
+}
+
+// ***** ----- Error Handling ----- ***** //
+
+function handleError(status: number) {
+  if (status === 404) {
+    throw Error('404')
+  }
+
+  if (status === 500) {
+    throw Error('500')
+  }
+
+  throw Error('Sorry, something went wrong.')
 }

--- a/src/util/api-calls.ts
+++ b/src/util/api-calls.ts
@@ -2,10 +2,20 @@ import {cleanListData} from './utilities'
 
 // Maybe getCategoryOf and error handling?
 
+const listEndpoint = 'https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b'
+const errorEndpoint = 'https://httpstat.us/404'
+
 export const getLists = () => {
-  return fetch('https://api.nytimes.com/svc/books/v3/lists/names.json?api-key=A7HbLAtK8PlqUjAQ0Ol77w3tNU1cZS4b')
-    .then(response => response.json())
+  return fetch(errorEndpoint)
+    .then(response => {
+      if (response.ok) {
+        return response.json()
+      }
+
+      console.log(response)
+    })
     .then(data => cleanListData(data.results))
+    .catch(error => console.log(error))
 }
 
 export const getTypeOf = ( typeOf: string ) => {


### PR DESCRIPTION
### Pull Request Template

##### Description

Added error handling for category list fetching. Now, when 'response.ok' returns `false` an error handler method is called and throws an error message based upon the status code it receives. There are three error messages: one for a 404, one for a 500, and one for any other errors - we can make this more robust in the future if need be. 

When the error is thrown, a 'catch' within App will see this and set a property within state, 'error', to the value of the error message thrown. This error is then conditionally rendered in the same spot that our 'Loading...' message currently is.

##### What's changed & where should the reviewer start?

Both 'apiCalls.ts' and 'App.tsx' have been updated to look for and respond to response errors given by the API.

To verify that the error handling is functioning, replace the current fetched URL, for `getLists()`, with http://httpstat.us/ and add an error code to the end of the url - for example, to see a 404, use http://httpstat.us/404 and verify that the message appears on the home page.

##### Relevant Screenshots/GIFs

Error message when 404 is returned from fetch:

![Screen Shot 2021-05-30 at 4 58 14 PM](https://user-images.githubusercontent.com/75702270/120122900-008e8880-c169-11eb-9171-4c3f08695ec1.png)

Error message when 500 is returned from fetch:

![Screen Shot 2021-05-30 at 4 58 30 PM](https://user-images.githubusercontent.com/75702270/120122908-14d28580-c169-11eb-9f4e-b089ff713db6.png)

Error message when any other status code (other than 200) is returned from fetch:

![Screen Shot 2021-05-30 at 4 58 48 PM](https://user-images.githubusercontent.com/75702270/120122917-2025b100-c169-11eb-9048-d96908d88011.png)

What is it?
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Refactoring

### Checklist:
- [x] My code follows the guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] Any dependent changes have been merged and published in downstream module
