### PR TITLE
Debug favorties section so bookcards appear instead of 'loading'

### DIFF
--- a/src/Components/Bookshelf/Bookshelf.tsx
+++ b/src/Components/Bookshelf/Bookshelf.tsx
@@ -72,16 +72,22 @@ class Bookshelf extends React.Component<BookshelfProps, BookshelfState> {
       })
     }
 
-    return (
-      !this.state.books ? <h3>Loading</h3>
-      : <div className='bookshelf-background'>
+    if (!this.props.favoriteBooks && !this.state.books) {
+      return (
+        <h3>Loading</h3>
+      )
+    } else {
+      return (
+        <div className='bookshelf-background'>
           <h2>{this.props.queryID}</h2>
           <section className='bookshelf'>
             {bookCards}
           </section>
         </div>
-    )
+      )
+    }
   }
+  
 }
 
 


### PR DESCRIPTION
### Pull Request Template

##### Description
Fixed bug so that when you click on favorites from Home, it doesn't get stuck on "loading" and will still render the favorited bookcards.


##### What's changed & where should the reviewer start?
Bookshelf.tsx


##### Relevant Screenshots/GIFs


### Fixes



#### Type of change
What is it?
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Refactoring

### Checklist:
- [X] My code follows the guidelines of this project
- [X] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [X] My changes generate no new warnings
- [ ] Any dependent changes have been merged and published in downstream module
